### PR TITLE
Mudamos o nome do projeto Android para isusapp

### DIFF
--- a/android/app/src/main/java/com/esp/isus/MainActivity.java
+++ b/android/app/src/main/java/com/esp/isus/MainActivity.java
@@ -10,6 +10,6 @@ public class MainActivity extends ReactActivity {
    */
   @Override
   protected String getMainComponentName() {
-    return "iSUS";
+    return "isusapp";
   }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'iSUS'
+rootProject.name = 'isusapp'
 include ':@react-native-community_async-storage'
 project(':@react-native-community_async-storage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/async-storage/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "iSUS",
-  "displayName": "isusapp",
+  "name": "isusapp",
+  "displayName": "iSUS",
   "ios": {
     "bundleIdentifier": "com.esp.isus"
   },


### PR DESCRIPTION
#56 
Alteramos o nome do projeto no `app.json` para "isusapp" para que ele pudesse compilar para ambas as plataformas sem precisar de nenhuma alteração manual.