### PR TITLE
Feature/151 ajustar exibicao título header

### DIFF
--- a/src/pages/WebView/index.js
+++ b/src/pages/WebView/index.js
@@ -12,6 +12,8 @@ export default function WebViewPage({ navigation, route }) {
   const widthView = Dimensions.get('window').width;
   console.log(widthView);
   let res = '';
+  
+  // verificando o tamanho da tela do dispositivo para limitar os caracteres.
   if (widthView <= 320) {
     // eslint-disable-next-line no-unused-expressions
     (route.params.title.length > 35) ? res = `${route.params.title.substring(0, 24).trim()}...` : res = route.params.title;
@@ -19,7 +21,6 @@ export default function WebViewPage({ navigation, route }) {
     // eslint-disable-next-line no-unused-expressions
     (route.params.title.length > 35) ? res = `${route.params.title.substring(0, 35).trim()}...` : res = route.params.title;
   }
-  console.log(res);
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/src/pages/WebView/index.js
+++ b/src/pages/WebView/index.js
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect } from 'react';
 import {
-  TouchableOpacity
+  TouchableOpacity, Dimensions
 } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { useNavigation } from '@react-navigation/native';
@@ -8,6 +8,19 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 export default function WebViewPage({ navigation, route }) {
   const navigator = useNavigation();
+  console.log(route.params.title.length)  
+  const widthView = Dimensions.get('window').width;
+  console.log(widthView);
+  let res = '';
+  if (widthView <= 320) {
+    // eslint-disable-next-line no-unused-expressions
+    (route.params.title.length > 35) ? res = `${route.params.title.substring(0, 24).trim()}...` : res = route.params.title;
+  } else {
+    // eslint-disable-next-line no-unused-expressions
+    (route.params.title.length > 35) ? res = `${route.params.title.substring(0, 35).trim()}...` : res = route.params.title;
+  }
+  console.log(res);
+
   useLayoutEffect(() => {
     navigation.setOptions({
       headerStyle: {
@@ -15,7 +28,7 @@ export default function WebViewPage({ navigation, route }) {
       },
       headerTintColor: '#FFF',
       headerTitleAlign: 'center',
-      headerTitle: route.params.title,
+      headerTitle: res,
       headerLeft: () => (
         <TouchableOpacity
           style={{

--- a/src/routes/appDrawerScreen.js
+++ b/src/routes/appDrawerScreen.js
@@ -9,7 +9,9 @@ import {
   View,
   Dimensions,
   Text,
-  StyleSheet
+  StyleSheet,
+  Platform,
+  SafeAreaView
 } from 'react-native';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
@@ -28,17 +30,19 @@ function CustomDrawerContent(props) {
   const versaoSistema = packageJson.version;
   return (
     <>
+      <SafeAreaView style={styles.droidSafeArea}>
         <View
           style={{
             flexDirection: 'row',
-            marginTop: 20,
+            marginTop: 40,
             borderBottomWidth: 0.5,
-            borderBottomColor: '#c4c4c4'
+            borderBottomColor: '#C4C4C4',
           }}
         >
           <Heart size={40} style={{ margin: 10 }} />
         </View>
-      <DrawerContentScrollView {...props}>
+      </SafeAreaView>
+      <DrawerContentScrollView {...props} style={{ marginTop: -10 }}>
         <DrawerItem
           icon={() => <FontAwesomeIcon name="home" size={20} color="#111" />}
           label="Home"
@@ -139,5 +143,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 16,
     letterSpacing: 0.4,
-  }
+    margin: Platform.OS === 'android' ? 10 : 20
+  },
+  droidSafeArea: {
+    paddingTop: Platform.OS === 'android' ? 25 : 0
+  },
 });

--- a/src/routes/appDrawerScreen.js
+++ b/src/routes/appDrawerScreen.js
@@ -34,7 +34,7 @@ function CustomDrawerContent(props) {
         <View
           style={{
             flexDirection: 'row',
-            marginTop: 40,
+            marginTop: 20,
             borderBottomWidth: 0.5,
             borderBottomColor: '#C4C4C4',
           }}
@@ -42,7 +42,7 @@ function CustomDrawerContent(props) {
           <Heart size={40} style={{ margin: 10 }} />
         </View>
       </SafeAreaView>
-      <DrawerContentScrollView {...props} style={{ marginTop: -10 }}>
+      <DrawerContentScrollView {...props} style={{ marginTop: 0 }}>
         <DrawerItem
           icon={() => <FontAwesomeIcon name="home" size={20} color="#111" />}
           label="Home"


### PR DESCRIPTION
Issue #151 finalizada. O titulo é exibido de acordo com o tamanho do dispositivo. Testado em android com 4" e 5" e no iphone o @brunoCostaSouza testou no simulador iPhone 11 e iPhone SE.
@ItaloRod da uma conferida ai.