### PR TITLE
💬 #558 - corrige mensagem de sucesso da tela de edição profissional

### DIFF
--- a/src/constantes/textos.js
+++ b/src/constantes/textos.js
@@ -12,7 +12,9 @@ const PERFIL = {
   },
   EDICAO_INFO_PROFISSIONAL: {
     CABECALHO: 'Informações Profissionais',
-    MSG_ERRO_SALVAR: 'Houve um problema ao salvar os dados.'
+    MSG_ERRO_SALVAR: 'Houve um problema ao salvar os dados.',
+    MSG_SUCESSO: 'Parabéns! Você atualizou suas informações profissionais. '
+    + 'Você será redirecionado para sua página de Perfil.'
   }
 };
 

--- a/src/pages/Perfil/EdicaoInfoProfissional/index.js
+++ b/src/pages/Perfil/EdicaoInfoProfissional/index.js
@@ -66,7 +66,7 @@ function EdicaoInfoProfissional() {
             if (result) {
               navigation.navigate('TelaDeSucesso',
                 {
-                  textoApresentacao: CONST_TEXT.PERFIL.EDICAO_INFO_PESSOAIS.MSG_SUCESSO,
+                  textoApresentacao: CONST_TEXT.PERFIL.EDICAO_INFO_PROFISSIONAL.MSG_SUCESSO,
                   telaDeRedirecionamento: ROTAS.PERFIL,
                   telaDeBackground: CORES.VERDE
                 });


### PR DESCRIPTION
Responsáveis:  
@Laysacunha 

Linked Issue:  
Close #558 

### Descrição

A tela de sucesso de edição de informações profissionais retornava o texto de sucesso da tela de edição de informações pessoais. Observou-se que existia uma texto constante que apontava para ambas as telas. Foi adicionado novo texto constante com as informações corretas.

### Passos a passo para teste

- Realizar a edição de informações profissionais na tela de Meu Perfil
- Observar a mensagem de retorno na tela de sucesso se condiz com o procedimento realizado.
-


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
