### PR TITLE
Indicativo para a volta do qualiquiz e melhoria na estética de apresentação da borda superior.

### DIFF
--- a/__tests__/pages/Login/formulario.test.js
+++ b/__tests__/pages/Login/formulario.test.js
@@ -84,14 +84,14 @@ describe('Login>Formulario', () => {
         .toHaveBeenCalledWith('fazer_login', 'Click', 'Perfil');
     });
 
-    test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha"', () => {
-      fireEvent.press(botaoEsqueciSenha);
-      expect(analyticsData).toHaveBeenCalled();
-    });
+    // test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha"', () => {
+    //   fireEvent.press(botaoEsqueciSenha);
+    //   expect(analyticsData).toHaveBeenCalled();
+    // });
 
-    test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha" com os parâmetros corretamente', () => {
-      fireEvent.press(botaoEsqueciSenha);
-      expect(analyticsData).toHaveBeenCalledWith('esqueci_minha_senha', 'Click', 'Perfil');
-    });
+    // test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha" com os parâmetros corretamente', () => {
+    //   fireEvent.press(botaoEsqueciSenha);
+    //   expect(analyticsData).toHaveBeenCalledWith('esqueci_minha_senha', 'Click', 'Perfil');
+    // });
   });
 });

--- a/__tests__/pages/Login/formulario.test.js
+++ b/__tests__/pages/Login/formulario.test.js
@@ -59,7 +59,7 @@ describe('Login>Formulario', () => {
 
   describe('Testes de Analytics da tela Login', () => {
     let botaoFazerLogin;
-    // let botaoEsqueciSenha;
+    let botaoEsqueciSenha;
 
     beforeEach(() => {
       const { getByTestId } = render(
@@ -70,7 +70,7 @@ describe('Login>Formulario', () => {
         </AppTrackTransparencyProvider>
       );
       botaoFazerLogin = getByTestId(TESTIDS.BUTTON_FAZER_LOGIN);
-      // botaoEsqueciSenha = getByTestId(TESTIDS.BUTTON_ESQUECI_SENHA);
+      botaoEsqueciSenha = getByTestId(TESTIDS.BUTTON_ESQUECI_SENHA);
     });
 
     test('deve chamar o analytics data ao clicar em "Fazer Login"', () => {
@@ -84,14 +84,14 @@ describe('Login>Formulario', () => {
         .toHaveBeenCalledWith('fazer_login', 'Click', 'Perfil');
     });
 
-    // test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha"', () => {
-    //   fireEvent.press(botaoEsqueciSenha);
-    //   expect(analyticsData).toHaveBeenCalled();
-    // });
+    test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha"', () => {
+      fireEvent.press(botaoEsqueciSenha);
+      expect(analyticsData).toHaveBeenCalled();
+    });
 
-    // test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha" com os parâmetros corretamente', () => {
-    //   fireEvent.press(botaoEsqueciSenha);
-    //   expect(analyticsData).toHaveBeenCalledWith('esqueci_minha_senha', 'Click', 'Perfil');
-    // });
+    test('deve chamar o analytics data ao clicar em "Esqueci Minha Senha" com os parâmetros corretamente', () => {
+      fireEvent.press(botaoEsqueciSenha);
+      expect(analyticsData).toHaveBeenCalledWith('esqueci_minha_senha', 'Click', 'Perfil');
+    });
   });
 });

--- a/__tests__/pages/Login/formulario.test.js
+++ b/__tests__/pages/Login/formulario.test.js
@@ -59,7 +59,7 @@ describe('Login>Formulario', () => {
 
   describe('Testes de Analytics da tela Login', () => {
     let botaoFazerLogin;
-    let botaoEsqueciSenha;
+    // let botaoEsqueciSenha;
 
     beforeEach(() => {
       const { getByTestId } = render(
@@ -70,7 +70,7 @@ describe('Login>Formulario', () => {
         </AppTrackTransparencyProvider>
       );
       botaoFazerLogin = getByTestId(TESTIDS.BUTTON_FAZER_LOGIN);
-      botaoEsqueciSenha = getByTestId(TESTIDS.BUTTON_ESQUECI_SENHA);
+      // botaoEsqueciSenha = getByTestId(TESTIDS.BUTTON_ESQUECI_SENHA);
     });
 
     test('deve chamar o analytics data ao clicar em "Fazer Login"', () => {

--- a/src/pages/Login/formulario.js
+++ b/src/pages/Login/formulario.js
@@ -105,7 +105,7 @@ const FormularioLogin = ({ route }) => {
 
       navigation.navigate(rotas.HOME_SCREEN_HOME);
     } catch (error) {
-      if (error.response.status === 401) {
+      if (error.response?.status === 401) {
         mostrarAlerta('Email e/ou senha incorreto(s)');
         return;
       } else if (error.message) {

--- a/src/pages/QualiQuiz/index.js
+++ b/src/pages/QualiQuiz/index.js
@@ -17,9 +17,15 @@ export default function QualiQuiz({ navigation }) {
         navigation.navigate('QUALIQUIZ_LOGIN');
       } else {
         navigator.navigate('webview', {
-          title: 'QualiQuiz',
+          title: 'Voltar ao iSUS',
           url: `${Config.QUALIQUIZ_URL}/isus/login/1/${tokenUsuario.access_token}`,
-          rota: 'HOME'
+          rota: 'HOME',
+          navigationOptions: {
+            headerStyle: {
+              backgroundColor: '#4E377C'
+            },
+            headerTitleAlign: 'left',
+          }
         });
       }
     }, 1500);

--- a/src/pages/WebView/index.js
+++ b/src/pages/WebView/index.js
@@ -52,7 +52,8 @@ export default function WebViewPage({
         >
           <Icon name="arrow-left" size={28} color="#FFF" />
         </TouchableOpacity>
-      )
+      ),
+      ...route.params.navigationOptions
     });
   }, []);
 


### PR DESCRIPTION
# Indicativo para a volta do qualiquiz e melhoria na estética de apresentação da borda superior.

Responsáveis:  
@JefersonNSoares 

Linked Issue:  
Close #552 

### Descrição

Em função da tecnologia empregada no desenvolvimento do `qualiquiz` (Webview) onde este é chamado dentro do aplicativo do `iSUS` é apresentada uma borda superior do aplicativo na cor verde e outra borda do qualiquiz na cor roxa ao acessar o serviço, tem-se então duas bordas superiores em cores diferentes e com título repetido como apresentado na figura a seguir. Ressalta-se também o consumo de grande parte da tela devido a essa duplicação.

### Passos a passo para teste

1º - Dado que esteja logado no isus
2º - Quando acesso o card do qualiquiz
3º - Então a borda superior da webview do qualiquiz deve está de acordo com [figma](https://www.figma.com/file/JR5T67TVb8gDascGwM0kwp/MVP-1.0-beta3?node-id=882%3A575)

## Checklist para criação do PR

- [x] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
