### PR TITLE
Definir melhor a identificação de qual governo é o serviço "Ação do Governo"

### DIFF
--- a/src/pages/Home/Servicos.js
+++ b/src/pages/Home/Servicos.js
@@ -47,7 +47,7 @@ function Servicos({ navigation }) {
       }
     },
     {
-      ordem: 4,
+      ordem: 7,
       id: 'Fale_Conosco',
       titulo: 'Fale Conosco',
       ativo: true,
@@ -57,7 +57,7 @@ function Servicos({ navigation }) {
       }
     },
     {
-      ordem: 5,
+      ordem: 4,
       id: 'Acoes_do_governo',
       titulo: 'Ações do governo',
       ativo: true,
@@ -70,9 +70,9 @@ function Servicos({ navigation }) {
       }
     },
     {
-      ordem: 6,
+      ordem: 5,
       id: 'ESP',
-      titulo: 'ESP',
+      titulo: 'Escola de Saúde Pública - ESP/CE',
       icone: Servico5,
       ativo: true,
       navegacao: {
@@ -83,7 +83,7 @@ function Servicos({ navigation }) {
       }
     },
     {
-      ordem: 7,
+      ordem: 6,
       id: 'ESP_Virtual',
       titulo: 'ESP Virtual',
       ativo: true,
@@ -150,7 +150,7 @@ function Servicos({ navigation }) {
 
   return (
     <View>
-      <Titulo>Serviços</Titulo>
+      <Titulo>Serviços SUS Ceará</Titulo>
       <Carrossel
         dados={listaServicos.sort((a, b) => a.ordem - b.ordem)}
         aoRenderizarItem={({ item }) => (


### PR DESCRIPTION
# Definir melhor a identificação de qual governo é o serviço "Ação do Governo"

Responsáveis:  
@JefersonNSoares 

Linked Issue:  
Close #549 

### Descrição

Como pessoa usuária do isus deseja se identificar melhor de qual estado é o serviço "Ação do Governo" para ter uma maior clareza da informação. Esta issue está relacionada a solicitação: 
- Feedback: EscolaDeSaudePublica/isus-app#473 

### Passos a passo para teste

Dado que acesso o isus então na tela home_screen deve renderizar com as devidas modificações:
- Label do primeiro grupo de ícones   deve ser `Serviços SUS Ceará`
- o 6ª card deve ter nome de label `Escola de Saúde Pública - ESP/CE`
- A ordem dos cards deve seguir a proposta do [figma](https://www.figma.com/file/FLKurtBDSBYAiYcS5xAPYC/iSUS?node-id=6827%3A8450) no qual há uma alteração, o card do `qualiquiz` para para 1º na ordem



## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
