### PR TITLE
⚡️ #597 - trata espaços no campo de email no cadastro

### DIFF
--- a/src/pages/NovoCadastro/formularioInfoPessoal.js
+++ b/src/pages/NovoCadastro/formularioInfoPessoal.js
@@ -201,7 +201,7 @@ export default function FormularioInfoPessoal({ navigation }) {
           name="email"
           keyboardType="email-address"
           onChangeText={text => {
-            alteraValor('email', text);
+            alteraValor('email', text.trim());
           }}
           mode="outlined"
           theme={


### PR DESCRIPTION
Responsáveis:  
@Laysacunha 

Linked Issue:  
Close #597 

### Descrição

No momento do cadastro ao se colocar um espaço ao final do e-mail o campo ficava inválido. A proposta é enviar o valor sem espaços no início ou fim mesmo que o campo visualmente esteja com espaços.

### Passos a passo para teste

- Realizar cadastro e adicionar espaço ao final do e-mail.


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
