### PR TITLE
Feature/i652 tratamento de erros

### DIFF
--- a/src/components/MessageErrorCard/index.js
+++ b/src/components/MessageErrorCard/index.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Button, Card } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+const MessageErrorCard = props => {
+  const { title, subtitle, iconColor, iconName, ...rest } = props;
+
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Card {...rest}>
+      <Card.Title
+        title={title}
+        subtitle={subtitle}
+        left={props => <Icon name={iconName} color={iconColor} {...props} />}
+      />
+      <Card.Actions>
+        <Button onPress={() => setIsOpen(false)}>Fechar</Button>
+      </Card.Actions>
+    </Card>
+  );
+};
+
+export default MessageErrorCard;

--- a/src/hooks/useBanners.js
+++ b/src/hooks/useBanners.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import listaDeBanners from '~/pages/Home/Banners/listaDeBanners';
+import useAutenticacao from './useAutenticacao';
+
+export function useBanners() {
+  const [banners, setBanners] = useState([]);
+
+  const [error, setError] = useState(false);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { estaLogado } = useAutenticacao();
+
+  const featchBanners = async () => {
+    try {
+      setIsLoading(true);
+      const data = await listaDeBanners(estaLogado);
+      setBanners(data);
+    } catch (e) {
+      setError(e);
+      console.log(`Erro ao listar Banners. ${e}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    featchBanners();
+  },[]);
+
+  return { banners, error, isLoading };
+}

--- a/src/hooks/useCategorias.js
+++ b/src/hooks/useCategorias.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { pegarCategoriasArquitetura } from '~/apis/apiHome';
+import useAutenticacao from './useAutenticacao';
+
+export function useCategorias() {
+  const [categorias, setCategorias] = useState([]);
+
+  const [error, setError] = useState(false);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { estaLogado } = useAutenticacao();
+
+  const featchcategorias = async () => {
+    try {
+      setIsLoading(true);
+      const data = await pegarCategoriasArquitetura(estaLogado);
+      setCategorias(data);
+    } catch (e) {
+      setError(e);
+      console.log(`Erro ao listar categorias. ${e}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    featchcategorias();
+  },[]);
+
+  return { categorias, error, isLoading };
+}

--- a/src/pages/Content/EstruturaConteudo/index.js
+++ b/src/pages/Content/EstruturaConteudo/index.js
@@ -64,7 +64,11 @@ export default function({ navigation }) {
     });
   }, []);
 
-  if (categorias.length === 0) {
+  if(!categoria) {
+    return null;
+  }
+
+  if (categorias?.length === 0) {
     return <></>;
   }
 
@@ -82,7 +86,7 @@ export default function({ navigation }) {
           backgroundColor: CORES.VERDE,
         },
       }}>
-      {categorias.map(item => (
+      {categorias && categorias.map(item => (
         <Tab.Screen
           options={{ title: item.name }}
           name={`${categoria}_${item.slug.replace('-', '_')}`}

--- a/src/pages/Home/Banners/index.js
+++ b/src/pages/Home/Banners/index.js
@@ -1,35 +1,31 @@
-import React, { useState, useContext, useEffect } from 'react';
-import BannerCarrossel from './BannerCarrossel';
-import { AutenticacaoContext } from '~/context/AutenticacaoContext';
-import listaBanners from './listaDeBanners';
+import React from 'react';
 import { ActivityIndicator } from 'react-native';
+import MessageErrorCard from '~/components/MessageErrorCard/index';
 import { CORES } from '~/constantes/estiloBase';
+import { useBanners } from '~/hooks/useBanners';
+import BannerCarrossel from './BannerCarrossel';
 
 const Banners = ({ sliderWidth, itemWidth }) => {
-  const [banners, setBanners] = useState([]);
+  const { banners, error, isLoading } = useBanners();
 
-  const { estaLogado } = useContext(AutenticacaoContext);
-
-  const carregarBaners = async () => {
-    try {
-      const mostrarBanners = await listaBanners(estaLogado);
-
-      setBanners(mostrarBanners);
-    } catch (error) {
-      console.log(`erro ao listar Banners. ${error}`);
-    }
-  };
-
-  useEffect(() => {
-    carregarBaners();
-  }, [estaLogado]);
-
-  if (banners.length <= 0) {
+  if (isLoading) {
     return (
       <ActivityIndicator
         size="large"
         color={CORES.VERDE}
         style={{ marginVertical: 10 }}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <MessageErrorCard
+        title="Error"
+        subtitle="Error ao carregar os banners"
+        iconColor={CORES.LARANJA}
+        iconName="alert"
+        style={{ margin: 10 }}
       />
     );
   }


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira @JefersonNSoares 

Linked Issue:  
Close #652 

### Descrição

Realizado tratamento de erro para o carregamento dos banners.

### Passos a passo para teste

Dado que acesso a o iSUS
Banners não recuperados da api
Deve aparecer mensagem de erros no local dos banners

### Observações

Criado um hook customizado para encapsular o carregamento dos banners com erro e loading.

```javascript
const { 
  banners, // lista dos banners
  error, // false ou objeto de Error, caso algum erro tenha acontecido
  isLoading, // true para carregando e false para carregado
} = useBanners();
```

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
