### PR TITLE
#657 - define cor para componentes do Elmo, Perfil e página de denúncia.

### DIFF
--- a/src/pages/Denunciar/index.js
+++ b/src/pages/Denunciar/index.js
@@ -6,6 +6,7 @@ import { DefaultTheme } from 'react-native-paper';
 import SetaEsquerda from '~/assets/icons/seta_esquerda.svg';
 import BarraDeStatus from '~/components/barraDeStatus';
 import rotas from '~/constantes/rotas';
+import { CORES } from '~/constantes/estiloBase';
 import {
   BotaoEmail,
   BotaoLigarSus,
@@ -74,7 +75,7 @@ export default function Denunciar() {
       <ScrollView>
         <Container>
           <ImagemFarol />
-          <Titulo testID="texto1">
+          <Titulo color={CORES.PRETO54} testID="texto1">
             O coronavírus continua circulando em nosso estado. Você pode ajudar
             a combater denunciando aglomerações e/ou não uso de máscaras.
           </Titulo>

--- a/src/pages/Denunciar/styles.js
+++ b/src/pages/Denunciar/styles.js
@@ -25,6 +25,7 @@ export const Titulo = styled.Text`
   margin-left: 16px;
   margin-right: 16px;
   text-align: center;
+  color: ${props => (props.color ? props.color : 'black')}
 `;
 
 export const TextoEmailLigacao = styled.Text`

--- a/src/pages/Elmo/SobreElmo/index.js
+++ b/src/pages/Elmo/SobreElmo/index.js
@@ -61,7 +61,7 @@ export default function SobreElmo() {
         barStyle="light-content"
       />
       <ScrollView style={{ flex: 1 }}>
-        <Titulo> Sobre o Elmo </Titulo>
+        <Titulo color={CORES.PRETO54}> Sobre o Elmo </Titulo>
         <Imagem source={ImageElmo} />
 
         <View style={{ marginHorizontal: 16, marginTop: 18 }}>

--- a/src/pages/Elmo/index.js
+++ b/src/pages/Elmo/index.js
@@ -248,7 +248,7 @@ function Elmo() {
         )}
         <View style={{ justifyContent: 'space-between', flexDirection: 'row' }}>
           <NovidadesTitle>
-            <TituloH6>Novidades</TituloH6>
+            <TituloH6 color={CORES.PRETO54}>Novidades</TituloH6>
             <BotaoLink
               color={CORES.LARANJA}
               marginTop={20}

--- a/src/pages/Elmo/styles.js
+++ b/src/pages/Elmo/styles.js
@@ -63,6 +63,7 @@ export const Hyperlink = styled.Text`
 
 export const TituloH6 = styled.Text`
   /* styleName: H6; */
+  color: ${props => (props.color ? props.color : 'black')};
   font-size: 20px;
   font-style: normal;
   font-weight: 500;
@@ -70,6 +71,7 @@ export const TituloH6 = styled.Text`
 `;
 export const Titulo = styled.Text`
   /* styleName: H5; */
+  color: ${props => (props.color ? props.color : 'black')};
   font-size: 24px;
   font-style: normal;
   font-weight: 400;

--- a/src/pages/Perfil/excluirPerfil.js
+++ b/src/pages/Perfil/excluirPerfil.js
@@ -234,6 +234,7 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     marginLeft: 16,
     marginRight: 16,
+    color: 'rgba(0, 0, 0, 0.54)'
   },
   campoDeTexto: {
     marginLeft: 16,


### PR DESCRIPTION
Responsáveis:  
@Laysacunha 

Linked Issue:  
Close #657 

### Descrição

Textos aparecem em branco no Android 11

### Passos a passo para teste

- Acessar tela de Saiba mais do Elmo no Android 11 > Título acima da imagem deve aparecer
- Acessar tela do Elmo no Android 11 > Titulo Novidades ao lado esquerdo do botão Ver Mais deve aparecer.
- Acessar tela de exclusão de conta -> Texto de orientação para exclusão de conta deve aparecer (acima do campo de texto).
- Acessar tela de denúncias -> texto abaixo da imagem deve aparecer

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
