### PR TITLE
🐛 fazendo navegação em WebViewPage com goBack()

### DIFF
--- a/src/components/listaCards/index.js
+++ b/src/components/listaCards/index.js
@@ -8,11 +8,10 @@ import ItemCard from './itemCard';
 export default function ListaCards({ lista }) {
   const navigation = useNavigation();
 
-  const netInfo = useNetInfo();
+  const { isConnected } = useNetInfo();
 
   const onPress = item => {
-    // analyticsData(item.id, 'Click', 'Elmo');
-    if (!netInfo.isConnected) {
+    if (!isConnected) {
       if (item.tipo === 'webview') {
         navigation.navigate(ROTAS.SEM_CONEXAO, {
           componente: 'webview',

--- a/src/pages/WebView/index.js
+++ b/src/pages/WebView/index.js
@@ -47,7 +47,7 @@ export default function WebViewPage({
               navigator.navigate(route.params.rota);
               return;
             }
-            navigator.popToTop();
+            navigator.goBack();
           }}>
           <Icon name="arrow-left" size={28} color="#FFF" />
         </TouchableOpacity>


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira 

Linked Issue:  

Close #649

### Descrição

O Botão voltar (superior esquerdo) dos cards internos da seção Elmo retornam para Home quando deveriam retornar para seção Elmo.

#### Analise do probema

Nosso código foi escrito seguindo a lógica de que quando fazemos uma navegação com o `navidation` para a rota `webview`, somos redirecionados para uma tela com que renderiza um webview com algumas coisas já predefinidas. Uma delas é que, por padrão, o botão de voltar leva para a **raiz** das rotas (no caso, a tela Home). 

#### Solução

Fazer com que o botão dé um `goBack()` no evento de `onPress` (por padrão).
 
### Passos a passo para teste

Acessar qualquer um dos itens que estão na tela `Elmo` e verificar se o botão de voltar está voltando para a tela anterior em vez de ir para a tela de `Home`.

## Checklist para criação do PR

- [x] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
