### PR TITLE
Atualização da lib de Async Storage

### DIFF
--- a/__mocks__/@react-native-community/async-storage.js
+++ b/__mocks__/@react-native-community/async-storage.js
@@ -1,1 +1,1 @@
-export default from '@react-native-community/async-storage/jest/async-storage-mock';
+export default from '@react-native-async-storage/async-storage/jest/async-storage-mock';

--- a/__tests__/asyncStorage.test.js
+++ b/__tests__/asyncStorage.test.js
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-community/async-storage';
+
+describe('Testes do AsyncStorage', () => {
+  beforeEach(() => {
+    AsyncStorage.clear();
+  });
+
+  it('Conseguir escrever e ler um item do AsyncStorage', async () => {
+    await AsyncStorage.setItem('username', 'testUser');
+
+    const usernameValue = await AsyncStorage.getItem('username');
+
+    expect(usernameValue).toBe('testUser');
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,10 +1,13 @@
 /* eslint-disable global-require */
-import { NativeModules } from 'react-native';
-import './__mocks__/@react-native-firebase';
-import 'react-native-gesture-handler/jestSetup';
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock';
+import { NativeModules } from 'react-native';
+import 'react-native-gesture-handler/jestSetup';
+import './__mocks__/@react-native-firebase';
 
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo);
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 NativeModules.RNCNetInfo = {
   getCurrentState: jest.fn(() => Promise.resolve()),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@hookform/resolvers": "^2.8.8",
     "@paralleldrive/feature-toggles": "^1.0.4",
     "@paralleldrive/react-feature-toggles": "^2.3.1",
-    "@react-native-community/async-storage": "^1.9.0",
+    "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/masked-view": "^0.1.7",
     "@react-native-community/netinfo": "^8.0.0",
     "@react-native-community/toolbar-android": "^0.2.1",

--- a/src/hooks/useAsyncStorage.js
+++ b/src/hooks/useAsyncStorage.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useState } from 'react';
 
 function useAsyncStorage(key, initialValue) {

--- a/src/services/armazenamento.js
+++ b/src/services/armazenamento.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import RNFetchBlob from 'rn-fetch-blob'; // Causando warning
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,12 +1177,12 @@
   resolved "https://registry.yarnpkg.com/@paralleldrive/react-feature-toggles/-/react-feature-toggles-2.3.1.tgz#7b4f105fcb003fd22a875f7718a737ec78751add"
   integrity sha512-GJbpD2R+h2s1SjlZgFGSlAMHSMJLJYuGk/0GMiVzubOchOun/dIZXp8HqYvNXvr4yOFU4Ocsgd8BgribBZIGrw==
 
-"@react-native-community/async-storage@^1.9.0":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
+"@react-native-async-storage/async-storage@^1.17.3":
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.3.tgz#fa7010aa9b6a811ff653df3698a90d3c173dd6a6"
+  integrity sha512-2dxdlGwBjBP2qYu6F72U7cRRFshISYiNEWCaQNOJtxUERCMaYRWcniYqhL248KSbGUMpRhFCEtliztsiGoYYMA==
   dependencies:
-    deep-assign "^3.0.0"
+    merge-options "^3.0.4"
 
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0"
@@ -3724,13 +3724,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -5998,11 +5991,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -6017,6 +6005,11 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -7407,6 +7400,13 @@ merge-deep@^3.0.2:
     arr-union "^3.1.0"
     clone-deep "^0.2.4"
     kind-of "^3.0.2"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Responsáveis

@ericsonmoreira @fpontef 

Linked Issue:

Close #704 

## Descrição

AsyncStorage é um sistema de armazenamento simples baseado em chave e valor (key-value), não criptografado, assíncrono e persistente, que é global para o aplicativo. Usamos o `AsyncStorage` para persistir algumas informações no device da pessoa usuária. Porém, a atual dependência que estamos usando para essa funcionalidade está depreciada. Isso pode acarretar em problemas de segurança e desenvolvimento pois estaremos usando uma dependência que não está sendo mais mantida/atualizada.

Lib depreciada que estamos usando: [@react-native-community/async-storage](https://www.npmjs.com/package/@react-native-community/async-storage)
Lib atual: [@react-native-async-storage/async-storage](https://react-native-async-storage.github.io/async-storage/)

## Observações

> 🚀 No final das contas, resolvemos continuar usando o nosso custom hook useAsyncStorage, pois nele já encapsulamos a lógica para transformar os valores que estão nos AsyncStora em formato de Objeto (e vice-versa).

## Checklist para criação do PR

- [x] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
