### PR TITLE
Fix module import definition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,10 @@
     "jest": true
   },
   "parser": "babel-eslint",
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "globals": {
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly",
@@ -21,12 +24,23 @@
     "ecmaVersion": 2019,
     "sourceType": "module"
   },
-  "plugins": ["react"],
+  "plugins": [
+    "react"
+  ],
   "rules": {
-    "indent": ["error", 2],
+    "indent": [
+      "error",
+      2
+    ],
     "linebreak-style": "off",
-    "quotes": ["error", "single"],
-    "semi": ["error", "always"],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
     "react/prop-types": "off",
     "react/display-name": "off",
     "no-console": "off"
@@ -36,7 +50,10 @@
       "version": "detect"
     },
     "import/resolver": {
-      "babel-plugin-root-import": {}
+      "babel-plugin-root-import": {
+        "rootPathPrefix": "~",
+        "rootPathSuffix": "src"
+      }
     }
   }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,10 +1,15 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"]
+      "~/*": [
+        "./src/*"
+      ]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ],
 }


### PR DESCRIPTION
## Responsáveis

@fpontef 

Linked Issue:
Sem issue.

## Descrição

Para habilitar ir até o módulo importado no editor, mesmo fazendo uso do babel-plugin-root-import, quando usar o "Go to Definition" ou CTRL + click do botão esquerdo do mouse.
Isso faz com que a navegação entre componentes fique mais fácil.

## Passos a passo para teste

1) No vscode ou vscodium abrir o projeto do isus-app
2) Procurar uma importação estilo:  import A from '~/componente/A';
3) Apertar o CTRL e clicar.
4) Conferir se ele vai até o componente.

## Observações
- No arquivo .eslint.json:
Correção para fazer o eslint seguir o componente usando o prefixo:  ~
Ex: import A from '~/componente/A';

- No arquivo jsconfig.json:
Correção para forçar ele reconhecer o componente:  A ao invés de A/index, via uso do  `"moduleResolution": "node"`
Correção para reconhecer a pasta ao usar o prefixo: ~  , colocando um `"./src/*"` ao invés de somente `src`.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [ ] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
