### PR TITLE
Feature/i778 ocultar acoes governo

### DIFF
--- a/__tests__/pages/Home/ServicosSUSCeara/servicos.test.js
+++ b/__tests__/pages/Home/ServicosSUSCeara/servicos.test.js
@@ -37,13 +37,14 @@ describe('Servicos', () => {
     expect(analyticsData).toHaveBeenCalled();
   });
 
-  test('deve chamar o analytics data ao clicar no serviço Ações do governo', () => {
-    const item = renderedObject.getByTestId(
-      'cartaoHome-servicos-Acoes_do_governo',
-    );
-    fireEvent.press(item);
-    expect(analyticsData).toHaveBeenCalled();
-  });
+  // TODO: voltar esse teste depois do período eleitoral
+  // test('deve chamar o analytics data ao clicar no serviço Ações do governo', () => {
+  //   const item = renderedObject.getByTestId(
+  //     'cartaoHome-servicos-Acoes_do_governo',
+  //   );
+  //   fireEvent.press(item);
+  //   expect(analyticsData).toHaveBeenCalled();
+  // });
 
   test('deve chamar o analytics data ao clicar no serviço ESP', () => {
     const item = renderedObject.getByTestId('cartaoHome-servicos-ESP');

--- a/src/pages/Home/Servicos/index.js
+++ b/src/pages/Home/Servicos/index.js
@@ -6,7 +6,7 @@ import ResidenciaMedicaIcon from '~/assets/icons/servicos/residencia_medica.svg'
 import Servico1 from '~/assets/icons/servicos/servico_1.svg';
 import Servico2 from '~/assets/icons/servicos/servico_2.svg';
 import Servico3 from '~/assets/icons/servicos/servico_3.svg';
-import Servico4 from '~/assets/icons/servicos/servico_4.svg';
+// import Servico4 from '~/assets/icons/servicos/servico_4.svg';
 import Servico5 from '~/assets/icons/servicos/servico_5.svg';
 import Servico6 from '~/assets/icons/servicos/servico_6.svg';
 import Servico7 from '~/assets/icons/servicos/servico_7.svg';
@@ -74,18 +74,19 @@ function Servicos({ navigation }) {
         componente: ROTAS.SUS_NO_CEARA,
       },
     },
-    {
-      id: 'Acoes_do_governo',
-      titulo: 'Ações do governo',
-      ativo: true,
-      icone: Servico4,
-      navegacao: {
-        net: true,
-        componente: 'webview',
-        titulo: 'Ações do governo',
-        url: 'https://coronavirus.ceara.gov.br/isus/governo/',
-      },
-    },
+    // TODO: abilitar Acoes_do_governo ao fim do período eleitoral
+    // {
+    //   id: 'Acoes_do_governo',
+    //   titulo: 'Ações do governo',
+    //   ativo: true,
+    //   icone: Servico4,
+    //   navegacao: {
+    //     net: true,
+    //     componente: 'webview',
+    //     titulo: 'Ações do governo',
+    //     url: 'https://coronavirus.ceara.gov.br/isus/governo/',
+    //   },
+    // },
     {
       id: 'ESP',
       titulo: 'Escola de Saúde Pública - ESP/CE',


### PR DESCRIPTION
## Responsáveis

@ericsonmoreira 

Linked Issue:

Close #778 

## Descrição

📢 A partir deste dia 2 DE JULHO, muda muita coisa de nossa comunicação interna e externa até as eleições.

1) Os grupos de Whatsapp e Telegram (Acontece na ESP) não poderão ser alimentados com notícias produzidas pela Ascom;
2) É vedado aos agentes públicos (nós todos) fazerem manifestações políticas estando dentro do seus horários de expediente;
3) É vedado aos agentes públicos fazerem manifestações políticas utilizando-se da wi-fi ou de celulares e computadores institucionais;
4) Os sites da ESP/CE (assim como todos os institucionais do Governo do Ceará) não poderão ser alimentados com notícias e terão notícias antigas desativadas;
5) Não poderemos enviar newsletters como Acontece na ESP e Informa ESP ;
6) Redes sociais estarão desativadas (Instagram, Youtube, Linkedin e Facebook), ou seja, também não teremos lives.

Como o iSUS é uma das ferramentas que fazem parte das estratégias de comunicação da ESP, faz-se necessário ocultar o acesso ao botão `Ações do Governo` em `Serviços SUS Ceará` e lançar uma nova versão do app.

## Passos a passo para teste

1. Acessar a tela inicial do app
2. Verificar se o botão `Ações do Governo` em `Serviços SUS Ceará` **não** está aparecendo. 

## Observações

> Apenas ocultar.

## Checklist para criação do PR

- [X] Testes foram implementados (novos ou não)
- [X] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [X] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
